### PR TITLE
Create `FilterBuilder::FormParams` class

### DIFF
--- a/lib/filter_builder/form.rb
+++ b/lib/filter_builder/form.rb
@@ -4,7 +4,7 @@ module FilterBuilder
 
     def initialize(filtered_class, params = {})
       @filtered_class = filtered_class
-      @filter_params = FilterBuilder::Form::Params.new(params.to_h)
+      @filter_params = FilterBuilder::FormParams.new(params.to_h)
     end
 
     def results
@@ -19,34 +19,6 @@ module FilterBuilder
 
     def filter
       FilterBuilder::Filter.new(filtered_class, filter_params)
-    end
-
-    class Params
-      attr_reader :attributes
-
-      def initialize(params)
-        @attributes = RecursiveOpenStruct.new(params.to_h)
-      end
-
-      def filter_params
-        @filter_params ||= deep_cast(attributes)
-      end
-
-      def to_h
-        filter_params.to_h
-      end
-
-      private
-
-      def deep_cast(struct)
-        struct.to_h.transform_values do |val|
-          case val
-          when Array then val.map(&:presence)
-          when Hash then deep_cast(val).presence
-          else val.presence
-          end
-        end.compact
-      end
     end
   end
 end

--- a/lib/filter_builder/form_params.rb
+++ b/lib/filter_builder/form_params.rb
@@ -1,0 +1,29 @@
+module FilterBuilder
+  class FormParams
+    attr_reader :attributes
+
+    def initialize(params)
+      @attributes = RecursiveOpenStruct.new(params.to_h)
+    end
+
+    def filter_params
+      @filter_params ||= deep_cast(attributes)
+    end
+
+    def to_h
+      filter_params.to_h
+    end
+
+    private
+
+    def deep_cast(struct)
+      struct.to_h.transform_values do |val|
+        case val
+        when Array then val.map(&:presence)
+        when Hash then deep_cast(val).presence
+        else val.presence
+        end
+      end.compact
+    end
+  end
+end


### PR DESCRIPTION
This PR decouples two responsibilities of the `FilterBuilder::Form`,  1 - providing an interface to the Filter results & 2 - transforming parameters, by creating a separate `FilterBuilder::FormParams` class.  It adds some flexibility to more easily tap into behavior already present in `FilterBuilder` 

There's at least 2 places in the RMA where we create a new `FilterBuilder::Form` and first want to check if the params are empty to avoid firing off an expensive query.  

Checking if the params are "empty", ie no empty string values, no empty arrays, etc, at any arbitrary depth of nesting, is an ability thats already possessed by the FilterBuilder::Form by calling `deep_cast` on the `RecursiveOpenStruct`ified params hash. **But,** it's difficult to tap into that ability directly given the current implementation.

#### Two examples from the RMA
* [Billing::ClaimsController](https://github.com/relevant-healthcare/rma/blob/efc10c45d4ea29e3c69abf64423ca973a6084344/app/controllers/billing/claims_controller.rb#L8)
```ruby
  def index
    @filter = FilterBuilder::Form.new(current_user.claims, filter_params)

    @claims = if @filter.filter_params.any? 
                @filter.results
                       .page(params[:page])
                       .order(:id)
              else
                Billing::Claim.none
              end
  end
```
This leverages the `deep_cast` with `@filter.filter_params.any? `, but the query resulting from `current_user.claims` is fired off even when nothing needs to be rendered.

* [EncountersController](https://github.com/relevant-healthcare/rma/blob/master/app/controllers/encounters_controller.rb#L33)
```ruby
  def index
    @filter = FilterBuilder::Form.new(encounters, filter_params)

    @encounters = @filter
                  .results
                  .page(params[:page])
  end

  # ... omitting stuff ...
  
  def empty_params?
    FilterBuilder::Form.new(nil, filter_params).filter_params.any?
  end

  def encounters
    empty_params? ? current_user.patient_encounters : Patient::Encounter.none
  end
```
This avoids the unneeded query, but `FilterBuilder::Form.new(nil, filter_params).filter_params.any?` is  sorta clunky and in code review prompted the addition of a comment.

#### Proposed Pattern
```ruby
def index
  @filter = if FilterBuilder::FormParams.new(params).any?
               FilterBuilder::Form.new(resource, params)
            else 
               FilterBuilder::Form.new(Resource.none, params)
            end
  # .....
end
```
