### PR TITLE
Change `.filter` method to `.filterbuilder_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ FilterBuilder is used to dynamically filter an ActiveRecord model based on a has
 
 ## API
 
-Filter Builder implements `.filter` on ActiveRecord::Base, making `.filter` available on any child of ActiveRecord::Base.
+Filter Builder implements `.filterbuilder_filter` on ActiveRecord::Base, making `.filterbuilder_filter` available on any child of ActiveRecord::Base.
 
-### `.filter`
+### `.filterbuilder_filter`
 
 required argument: Hash
 
@@ -63,27 +63,27 @@ end
 
 **Filtering by column**:
 
-`Patient.filter(first_name: 'My Name')` is equivalent to `Patient.where(first_name: 'My Name')`
+`Patient.filterbuilder_filter(first_name: 'My Name')` is equivalent to `Patient.where(first_name: 'My Name')`
 
 **Filtering by a belongs_to association**:
 
-`Patient.filter(provider: { npi: 'some_npi' })` is equivalent to `Patient.joins(:provider).merge(Provider.where(npi: some_npi))`
+`Patient.filterbuilder_filter(provider: { npi: 'some_npi' })` is equivalent to `Patient.joins(:provider).merge(Provider.where(npi: some_npi))`
 
 **Filtering by a scope**:
 
-`Patient.filter(born_after: 5.years.ago)` is equivalent to `Patient.born_after(5.years.ago)`
+`Patient.filterbuilder_filter(born_after: 5.years.ago)` is equivalent to `Patient.born_after(5.years.ago)`
 
 Filter Builder will look for scopes that match the keyword prefix with "with". For example:
 
-`Provider.filter(age: 28)` is equivalent to `Provider.with_age(28)`
+`Provider.filterbuilder_filter(age: 28)` is equivalent to `Provider.with_age(28)`
 
 By passing an empty hash as the argument, it's possible to call a scope without an argument. For example:
 
-`Provider.filter(missing_npi: [])` is equivalent to `Provider.missing_npi`
+`Provider.filterbuilder_filter(missing_npi: [])` is equivalent to `Provider.missing_npi`
 
 **Filtering using operator keywords**:
 
-Example: `Patient.filter(first_name: { matches_case_insensitive: 'Lars' })` is equivalent to `Patient.where("patients.first_name ~* 'Larse'")`
+Example: `Patient.filterbuilder_filter(first_name: { matches_case_insensitive: 'Lars' })` is equivalent to `Patient.where("patients.first_name ~* 'Larse'")`
 
 Supported operator keywords:
 
@@ -105,7 +105,9 @@ Supported operator keywords:
 - `cd filter_builder`
 - `bundle install`
 - Start postgres
-- Create a postgres user with name 'filter_builder' that can create databases
+- Create a postgres user with name "filter_builder" that can create databases:
+    - `psql postgres`
+    - `CREATE USER filter_builder WITH CREATEDB;`
 - `bundle exec rake db:reset`
 
 To run specs:

--- a/lib/filter_builder/conditions.rb
+++ b/lib/filter_builder/conditions.rb
@@ -10,67 +10,67 @@ module FilterBuilder
     end
 
     class Equals < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where(field.name => value)
       end
     end
 
     class DoesNotEqual < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where.not(field.name => value)
       end
     end
 
     class MatchesCaseInsensitive < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} ~* ?", value)
       end
     end
 
     class DoesNotMatchCaseInsensitive < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} !~* ?", value)
       end
     end
 
     class MatchesCaseSensitive < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} ~ ?", value)
       end
     end
 
     class DoesNotMatchCaseSensitive < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} !~ ?", value)
       end
     end
 
     class Gt < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} > ?", value)
       end
     end
 
     class Lt < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} < ?", value)
       end
     end
 
     class Gte < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} >= ?", value)
       end
     end
 
     class Lte < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} <= ?", value)
       end
     end
 
     class Between < Condition
-      def filter(scope)
+      def filterbuilder_filter(scope)
         scope.where("#{field.namespaced} BETWEEN :min AND :max", value)
       end
     end

--- a/lib/filter_builder/core_ext.rb
+++ b/lib/filter_builder/core_ext.rb
@@ -1,6 +1,6 @@
 if Module.const_defined? 'ActiveRecord::Base'
   ActiveRecord::Base.class_eval do
-    def self.filter(params)
+    def self.filterbuilder_filter(params)
       FilterBuilder::Filter.new(self, params).scope
     end
   end

--- a/lib/filter_builder/filter.rb
+++ b/lib/filter_builder/filter.rb
@@ -22,7 +22,7 @@ module FilterBuilder
             filtered_table: filtered_class.table_name,
             key: key,
             value: value
-          ).filter(acc)
+          ).filterbuilder_filter(acc)
         end
       end
     end

--- a/lib/filter_builder/form.rb
+++ b/lib/filter_builder/form.rb
@@ -8,7 +8,7 @@ module FilterBuilder
     end
 
     def results
-      filter.scope
+      filterbuiler_filter.scope
     end
 
     def method_missing(method, *args)
@@ -21,7 +21,7 @@ module FilterBuilder
 
     private
 
-    def filter
+    def filterbuiler_filter
       FilterBuilder::Filter.new(filtered_class, filter_params)
     end
 

--- a/lib/filter_builder/form.rb
+++ b/lib/filter_builder/form.rb
@@ -8,7 +8,7 @@ module FilterBuilder
     end
 
     def results
-      filterbuiler_filter.scope
+      filterbuilder_filter.scope
     end
 
     def method_missing(method, *args)
@@ -21,7 +21,7 @@ module FilterBuilder
 
     private
 
-    def filterbuiler_filter
+    def filterbuilder_filter
       FilterBuilder::Filter.new(filtered_class, filter_params)
     end
 

--- a/lib/filter_builder/where_chain.rb
+++ b/lib/filter_builder/where_chain.rb
@@ -29,8 +29,8 @@ module FilterBuilder
       @conditions = conditions
     end
 
-    def filter(scope)
-      conditions.reduce(scope) { |acc, clause| clause.filter(acc) }
+    def filterbuilder_filter(scope)
+      conditions.reduce(scope) { |acc, clause| clause.filterbuilder_filter(acc) }
     end
 
     private

--- a/spec/filter_builder/core_ext_spec.rb
+++ b/spec/filter_builder/core_ext_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'ActiveRecord::Base Extension' do
-  describe '.filter' do
+  describe '.filterbuilder_filter' do
     context 'when filtering based on attributes' do
       let!(:included_patient) do
         Fabricate :patient, first_name: 'TestFirst', last_name: 'TestLast'
@@ -20,7 +20,7 @@ describe 'ActiveRecord::Base Extension' do
       end
 
       it 'includes records with the specified fields' do
-        expect(Patient.filter(filter_params)).to contain_exactly included_patient
+        expect(Patient.filterbuilder_filter(filter_params)).to contain_exactly included_patient
       end
     end
 
@@ -33,7 +33,7 @@ describe 'ActiveRecord::Base Extension' do
       let(:filter_params) { { visits: { provider: { npi: 'some_npi' } } } }
 
       it 'includes records with the specified fields in their joined relationships' do
-        expect(Patient.filter(filter_params)).to contain_exactly included_patient
+        expect(Patient.filterbuilder_filter(filter_params)).to contain_exactly included_patient
       end
     end
 
@@ -44,7 +44,7 @@ describe 'ActiveRecord::Base Extension' do
       let(:filter_params) { { uds_universe: [] } }
 
       it 'includes records returned by the scope' do
-        expect(Visit.filter(filter_params)).to contain_exactly included_visit
+        expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
       end
     end
 
@@ -66,7 +66,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'includes records returned by the scope matching the filter key prepended by with_' do
-          expect(Patient.filter(filter_params)).to contain_exactly included_patient
+          expect(Patient.filterbuilder_filter(filter_params)).to contain_exactly included_patient
         end
       end
 
@@ -81,7 +81,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'includes records returned by the scope matching the filter key prepended by with_' do
-          expect(Patient.filter(filter_params)).to contain_exactly included_patient
+          expect(Patient.filterbuilder_filter(filter_params)).to contain_exactly included_patient
         end
       end
     end
@@ -94,14 +94,14 @@ describe 'ActiveRecord::Base Extension' do
         context 'when the filter key only matches a scope when prepended by with_' do
           let(:filter_params) { { date_on_or_after: ['2016-06-01'] } }
           it 'includes records returned by the scope matching filter key prepended by with_' do
-            expect(Visit.filter(filter_params)).to contain_exactly included_visit
+            expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
           end
         end
 
         context 'when the filter key matches a scope exactly' do
           let(:filter_params) { { with_date_on_or_after: ['2016-06-01'] } }
           it 'includes records returned by the scope matching filter key with no prefix' do
-            expect(Visit.filter(filter_params)).to contain_exactly included_visit
+            expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
           end
         end
       end
@@ -110,14 +110,14 @@ describe 'ActiveRecord::Base Extension' do
         context 'when the filter key only matches a scope when prepended by with_' do
           let(:filter_params) { { date_on_or_after: '2016-06-01' } }
           it 'includes records returned by the scope matching filter key prepended by with_' do
-            expect(Visit.filter(filter_params)).to contain_exactly included_visit
+            expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
           end
         end
 
         context 'when the filter key matches a scope exactly' do
           let(:filter_params) { { with_date_on_or_after: '2016-06-01' } }
           it 'includes records returned by the scope matching filter key with no prefix' do
-            expect(Visit.filter(filter_params)).to contain_exactly included_visit
+            expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
           end
         end
       end
@@ -130,14 +130,14 @@ describe 'ActiveRecord::Base Extension' do
       context 'when the filter key matches a scope exactly' do
         let(:filter_params) { { with_visit_sets: { id: :uds } } }
         it 'passes the hash argument correctly, returning scoped results' do
-          expect(Visit.filter(filter_params)).to contain_exactly included_visit
+          expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
         end
       end
 
       context 'when the filter key only matches a scope prepended by with_' do
         let(:filter_params) { { visit_sets: { id: :uds } } }
         it 'passes the hash argument correctly, returning scoped results' do
-          expect(Visit.filter(filter_params)).to contain_exactly included_visit
+          expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
         end
       end
     end
@@ -151,7 +151,7 @@ describe 'ActiveRecord::Base Extension' do
       end
 
       it 'still filters' do
-        expect(Visit.filter(filter_params)).to contain_exactly included_visit
+        expect(Visit.filterbuilder_filter(filter_params)).to contain_exactly included_visit
       end
     end
 
@@ -166,7 +166,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'includes results with matching values' do
-          expect(Provider.filter(filter_params)).to contain_exactly included_provider
+          expect(Provider.filterbuilder_filter(filter_params)).to contain_exactly included_provider
         end
       end
 
@@ -181,7 +181,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'refers to the filtered column unambiguously' do
-          expect(Provider.filter(filter_params)).to contain_exactly included_provider
+          expect(Provider.filterbuilder_filter(filter_params)).to contain_exactly included_provider
         end
       end
 
@@ -193,7 +193,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'returns records with matching values, case insensitive' do
-          expect(Provider.filter(filter_params)).to contain_exactly included_provider
+          expect(Provider.filterbuilder_filter(filter_params)).to contain_exactly included_provider
         end
       end
 
@@ -205,7 +205,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'returns records without matching values, case insensitive' do
-          expect(Provider.filter(filter_params)).to contain_exactly included_provider
+          expect(Provider.filterbuilder_filter(filter_params)).to contain_exactly included_provider
         end
       end
 
@@ -217,7 +217,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'returns records with matching values, case sensitve' do
-          expect(Provider.filter(filter_params)).to contain_exactly included_provider
+          expect(Provider.filterbuilder_filter(filter_params)).to contain_exactly included_provider
         end
       end
 
@@ -229,7 +229,7 @@ describe 'ActiveRecord::Base Extension' do
         end
 
         it 'returns records without matching values, case sensitve' do
-          expect(Provider.filter(filter_params)).to contain_exactly included_provider
+          expect(Provider.filterbuilder_filter(filter_params)).to contain_exactly included_provider
         end
       end
 
@@ -239,7 +239,7 @@ describe 'ActiveRecord::Base Extension' do
 
         context 'filtering to a scalar' do
           it 'returns records with equal values' do
-            expect(Provider.filter(npi: { equals: 'AC' })).to contain_exactly included_provider
+            expect(Provider.filterbuilder_filter(npi: { equals: 'AC' })).to contain_exactly included_provider
           end
         end
 
@@ -247,7 +247,7 @@ describe 'ActiveRecord::Base Extension' do
           let!(:other_included_provider) { Fabricate(:provider, npi: 'DC') }
 
           it 'includes records with a value in the collection' do
-            expect(Provider.filter(npi: { equals: %w[AC DC] })).to contain_exactly(
+            expect(Provider.filterbuilder_filter(npi: { equals: %w[AC DC] })).to contain_exactly(
               included_provider, other_included_provider
             )
           end
@@ -260,7 +260,7 @@ describe 'ActiveRecord::Base Extension' do
 
         context 'filtering to a scalar' do
           it 'returns records with unequal values' do
-            expect(Provider.filter(npi: { does_not_equal: '3AC' })).to contain_exactly included_provider
+            expect(Provider.filterbuilder_filter(npi: { does_not_equal: '3AC' })).to contain_exactly included_provider
           end
         end
 
@@ -268,7 +268,7 @@ describe 'ActiveRecord::Base Extension' do
           let!(:other_excluded_provider) { Fabricate(:provider, npi: 'DC') }
 
           it 'includes records without a value in the collection' do
-            expect(Provider.filter(npi: { does_not_equal: %w[3AC DC] })).to contain_exactly(
+            expect(Provider.filterbuilder_filter(npi: { does_not_equal: %w[3AC DC] })).to contain_exactly(
               included_provider
             )
           end
@@ -282,7 +282,7 @@ describe 'ActiveRecord::Base Extension' do
 
         context 'filtering to a scalar' do
           it 'returns records with greater numeric values' do
-            expect(Provider.filter(twelve_month_panel_target: { gt: 1 })).to contain_exactly(
+            expect(Provider.filterbuilder_filter(twelve_month_panel_target: { gt: 1 })).to contain_exactly(
               included_provider,
               other_included_provider
             )
@@ -297,7 +297,7 @@ describe 'ActiveRecord::Base Extension' do
 
         context 'filtering to a scalar' do
           it 'returns records with less than values' do
-            expect(Provider.filter(twelve_month_panel_target: { lt: 2 })).to contain_exactly(
+            expect(Provider.filterbuilder_filter(twelve_month_panel_target: { lt: 2 })).to contain_exactly(
               included_provider,
               other_included_provider
             )
@@ -312,7 +312,7 @@ describe 'ActiveRecord::Base Extension' do
 
         context 'filtering to a scalar' do
           it 'returns records with greater than or equals values' do
-            expect(Provider.filter(twelve_month_panel_target: { gte: 2 })).to contain_exactly(
+            expect(Provider.filterbuilder_filter(twelve_month_panel_target: { gte: 2 })).to contain_exactly(
               included_provider,
               other_included_provider
             )
@@ -327,7 +327,7 @@ describe 'ActiveRecord::Base Extension' do
 
         context 'filtering to a scalar' do
           it 'returns records with less than or equals values' do
-            expect(Provider.filter(twelve_month_panel_target: { lte: 1 })).to contain_exactly(
+            expect(Provider.filterbuilder_filter(twelve_month_panel_target: { lte: 1 })).to contain_exactly(
               included_provider,
               other_included_provider
             )
@@ -343,7 +343,7 @@ describe 'ActiveRecord::Base Extension' do
         let!(:other_excluded_provider) { Fabricate(:provider, twelve_month_panel_target: 4) }
 
         it "returns records between the min and max values" do
-          expect(Provider.filter(twelve_month_panel_target: { between: { min: 1, max: 3 }})).to contain_exactly(
+          expect(Provider.filterbuilder_filter(twelve_month_panel_target: { between: { min: 1, max: 3 }})).to contain_exactly(
             included_provider_one,
             included_provider_two,
             included_provider_three
@@ -355,7 +355,7 @@ describe 'ActiveRecord::Base Extension' do
     context 'with an unsupported operator keyword' do
       it 'raises the expected error' do
         expect do
-          Provider.filter(npi: { unsupported: 'foo'})
+          Provider.filterbuilder_filter(npi: { unsupported: 'foo'})
         end.to raise_error FilterBuilder::UnsupportedOperatorKeywordError
       end
     end


### PR DESCRIPTION
Context in [Google Doc Here](https://docs.google.com/document/d/1LCOySlCXy10k10hH7LMJQBZZ9Q_SE-cV92O7cmJ3K64/edit)... we can't use `filter` anymore because it interferes with ruby's filter method as of ruby 2.6

This PR changes the name to `filterbuilder_filter` so that we are sure the correct method is being used (see doc for more context). 

Testing: relying mostly on grepping/specs here; will also make a branch of RMA that relies on this to make sure that spec suite doesn't pick up anything either.